### PR TITLE
Add 'u/undo' command

### DIFF
--- a/2DBlocks/2DBlocks.vcxproj.user
+++ b/2DBlocks/2DBlocks.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/2DBlocks/main.cpp
+++ b/2DBlocks/main.cpp
@@ -24,7 +24,6 @@ int main()
     };
 
     World overworld{ corners.second, corners.first + 1 };
-
     while (prompt(overworld));
 
     return 0;
@@ -68,6 +67,10 @@ bool prompt(World& world)
         // also update printHelp().
         switch (choice.at(0))
         {
+        case 'B':
+        case 'b':
+            world.back();
+            break;
         case 'H':
         case 'h':
             printHelp();

--- a/2DBlocks/world.cpp
+++ b/2DBlocks/world.cpp
@@ -19,6 +19,7 @@ World::World(const Coord2D& start, const Coord2D& end)
     {
         m_grid.at(i).resize(size.getY());
     }
+    m_backupGrid = m_grid;
 };
 
 // Return a line of chr (no trailing new-line)
@@ -105,5 +106,12 @@ void World::place(const Tile& tile, const Coord2D& coord)
     assert(coord.isInRangeOf(*this));
 
     const auto index{ coord + m_offset };
+    m_backupGrid = m_grid;
     m_grid.at(index.getX()).at(index.getY()) = tile;
+}
+
+void World::back() {
+    x_type temp = m_grid;
+    m_grid = m_backupGrid;
+    m_backupGrid = temp;
 }

--- a/2DBlocks/world.h
+++ b/2DBlocks/world.h
@@ -18,6 +18,7 @@ private:
     using y_type = std::vector<Tile>;
     using x_type = std::vector<y_type>;
     x_type m_grid{};
+    x_type m_backupGrid{};
     Coord2D m_start{ 0, 0 }; // Bottom-left
     Coord2D m_end{ 1, 1 };   // Top-right + { 1, 1 }
 
@@ -34,6 +35,7 @@ public:
 
     const Tile& getTile(const Coord2D& coord) const;
     void place(const Tile& tile, const Coord2D& coord);
+    void back();
 
     const Coord2D& begin() const { return m_start; } // Bottom-left
     const Coord2D& end()   const { return m_end; }   // Top-right + { 1, 1 }


### PR DESCRIPTION
Added a simple command to undo your last action.
This was done by creating a new m_backupGrid variable, which is a copy of the grid from before the user's last action.
When placing a tile, m_backupGrid is set to the current m_grid before the tile is placed.
When going back, m_grid is set to m_backupGrid, and m_backupGrid is set to what m_grid was before going back, this is so you can undo going back. 

This approach may not be the most memory optimal solution, but it's incredibly easy to implement and can be used for any number of future grid operations. I also did not see a reason to heavily optimize this.